### PR TITLE
bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-media-queries",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Vue 2 media query helpers",
   "author": "flatanimals",
   "repository": "flatanimals/vue-media-queries",


### PR DESCRIPTION
The currently published version, 0.0.4, doesn't include the recently merged and documented Tailwind updates